### PR TITLE
set timezone as JST

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,6 +7,7 @@ from patients import PatientsReader
 
 class CovidDataManager:
     def __init__(self):
+        JST = datetime.timezone(datetime.timedelta(hours=+9), 'JST')
         self.data = {
             'contacts':{},
             'querents':{},
@@ -17,7 +18,7 @@ class CovidDataManager:
             'inspections':{},
             'inspections_summary':{},
             'better_patients_summary':{},
-            'last_update':datetime.datetime.now().isoformat(),
+            'last_update':datetime.datetime.now(JST).isoformat(),
             'main_summary':{}
         }
 


### PR DESCRIPTION
datetime.now()は、timezoneの指定がなければタイムゾーンが実行環境に依存しており、GitHub Actionsでは+-0として出力されていた（日本は+9）問題を修正。